### PR TITLE
Allow using GIT_COMMIT env variable to determine git commit

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,9 +35,9 @@ class ServerlessPlugin {
         return;
       }
 
-      const revision = execSync('git rev-parse --short HEAD').toString('utf8').trim();
+      const revision = process.env.GIT_COMMIT || execSync('git rev-parse --short HEAD').toString('utf8').trim();
       if (!revision) {
-        reject("Unable to determine git revision, is this a git repository?");
+        reject("Unable to determine git revision, run me in a git repository or pass GIT_COMMIT env variable");
         return;
       }
 


### PR DESCRIPTION
Useful for example when running serverless in a docker container, where you often don't want to have .git.