### PR TITLE
Follow permanent redirect so that POST to /deploy succeeds

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const http = require('http');
+const { http } = require('follow-redirects');
 const { execSync } = require('child_process');
 
 class ServerlessPlugin {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { http } = require('follow-redirects');
+const { https } = require('https');
 const { execSync } = require('child_process');
 
 class ServerlessPlugin {
@@ -43,7 +43,7 @@ class ServerlessPlugin {
 
       const environment = this.options.stage;
 
-      const request = http.request({
+      const request = https.request({
         method: 'POST',
         host: 'api.rollbar.com',
         path: '/api/1/deploy/',

--- a/package.json
+++ b/package.json
@@ -22,7 +22,5 @@
     "rollbar",
     "deployment"
   ],
-  "dependencies": {
-    "follow-redirects": "^1.14.1"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-rollbar-deploys",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "main": "lib/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -21,5 +21,8 @@
     "aws",
     "rollbar",
     "deployment"
-  ]
+  ],
+  "dependencies": {
+    "follow-redirects": "^1.14.1"
+  }
 }


### PR DESCRIPTION
Rollbar is reporting a `308 Moved` for the Deploy API. This aims to follow the redirect specified.